### PR TITLE
Wrong message on help text for Membership Cancellation settings

### DIFF
--- a/templates/CRM/Admin/Form/Setting/MembershipExtension.hlp
+++ b/templates/CRM/Admin/Form/Setting/MembershipExtension.hlp
@@ -74,6 +74,12 @@
   </p>
 {/htxt}
 
+{htxt id='id-cancel-date'}
+{/htxt}
+
+{htxt id='id-cancel-reason'}
+{/htxt}
+
 {htxt id='id-hide-auto-renewal'}
   <p>{ts domain='org.project60.membership'}The built-in auto renewal feature interferes with the P60 membership concept, so we recommend not to use it. If you activate this option the fields will be hidden from the UI and the column in the tab and the search result will be freed up for something else.{/ts}</p>
 {/htxt}

--- a/templates/CRM/Admin/Form/Setting/MembershipExtension.tpl
+++ b/templates/CRM/Admin/Form/Setting/MembershipExtension.tpl
@@ -58,11 +58,11 @@
       <h3>{ts domain="org.project60.membership"}Membership Cancellation{/ts}</h3>
       <table>
         <tr>
-          <td>{$form.membership_cancellation_date_field.label}&nbsp;<a onclick='CRM.help("{ts domain="org.project60.membership"}Membership Number Field{/ts}", {literal}{"id":"id-cancel-date","file":"CRM\/Admin\/Form\/Setting\/MembershipExtension"}{/literal}); return false;' href="#" title="{ts domain="org.project60.membership"}Help{/ts}" class="helpicon"></a></td>
+          <td>{$form.membership_cancellation_date_field.label}&nbsp;<a onclick='CRM.help("{ts domain="org.project60.membership"}Cancel Date Field{/ts}", {literal}{"id":"id-cancel-date","file":"CRM\/Admin\/Form\/Setting\/MembershipExtension"}{/literal}); return false;' href="#" title="{ts domain="org.project60.membership"}Help{/ts}" class="helpicon"></a></td>
           <td>{$form.membership_cancellation_date_field.html}</td>
         </tr>
         <tr>
-          <td>{$form.membership_cancellation_reason_field.label}&nbsp;<a onclick='CRM.help("{ts domain="org.project60.membership"}Show Number in SummaryView{/ts}", {literal}{"id":"id-cancel-reason","file":"CRM\/Admin\/Form\/Setting\/MembershipExtension"}{/literal}); return false;' href="#" title="{ts domain="org.project60.membership"}Help{/ts}" class="helpicon"></a></td>
+          <td>{$form.membership_cancellation_reason_field.label}&nbsp;<a onclick='CRM.help("{ts domain="org.project60.membership"}Cancel Reason Field{/ts}", {literal}{"id":"id-cancel-reason","file":"CRM\/Admin\/Form\/Setting\/MembershipExtension"}{/literal}); return false;' href="#" title="{ts domain="org.project60.membership"}Help{/ts}" class="helpicon"></a></td>
           <td>{$form.membership_cancellation_reason_field.html}</td>
         </tr>
       </table>

--- a/templates/CRM/Admin/Form/Setting/MembershipExtension.tpl
+++ b/templates/CRM/Admin/Form/Setting/MembershipExtension.tpl
@@ -58,11 +58,11 @@
       <h3>{ts domain="org.project60.membership"}Membership Cancellation{/ts}</h3>
       <table>
         <tr>
-          <td>{$form.membership_cancellation_date_field.label}&nbsp;<a onclick='CRM.help("{ts domain="org.project60.membership"}Membership Number Field{/ts}", {literal}{"id":"id-number","file":"CRM\/Admin\/Form\/Setting\/MembershipExtension"}{/literal}); return false;' href="#" title="{ts domain="org.project60.membership"}Help{/ts}" class="helpicon"></a></td>
+          <td>{$form.membership_cancellation_date_field.label}&nbsp;<a onclick='CRM.help("{ts domain="org.project60.membership"}Membership Number Field{/ts}", {literal}{"id":"id-cancel-date","file":"CRM\/Admin\/Form\/Setting\/MembershipExtension"}{/literal}); return false;' href="#" title="{ts domain="org.project60.membership"}Help{/ts}" class="helpicon"></a></td>
           <td>{$form.membership_cancellation_date_field.html}</td>
         </tr>
         <tr>
-          <td>{$form.membership_cancellation_reason_field.label}&nbsp;<a onclick='CRM.help("{ts domain="org.project60.membership"}Show Number in SummaryView{/ts}", {literal}{"id":"id-number-show","file":"CRM\/Admin\/Form\/Setting\/MembershipExtension"}{/literal}); return false;' href="#" title="{ts domain="org.project60.membership"}Help{/ts}" class="helpicon"></a></td>
+          <td>{$form.membership_cancellation_reason_field.label}&nbsp;<a onclick='CRM.help("{ts domain="org.project60.membership"}Show Number in SummaryView{/ts}", {literal}{"id":"id-cancel-reason","file":"CRM\/Admin\/Form\/Setting\/MembershipExtension"}{/literal}); return false;' href="#" title="{ts domain="org.project60.membership"}Help{/ts}" class="helpicon"></a></td>
           <td>{$form.membership_cancellation_reason_field.html}</td>
         </tr>
       </table>


### PR DESCRIPTION
I keep the help texts empties because I am not sure of how the field works. It will be necessary to document it.