### PR TITLE
Fixes #34

### DIFF
--- a/CRM/Membership/PaidByLogic.php
+++ b/CRM/Membership/PaidByLogic.php
@@ -659,6 +659,14 @@ class CRM_Membership_PaidByLogic
       return; // Do not calculate the new end date as the contribution is not yet completed.
     }
 
+    //Check whether this is the first contribution of the membership
+    $contributionCount = CRM_Core_DAO::singleValueQuery("SELECT COUNT(*) FROM civicrm_membership_payment WHERE membership_id = %1", array(1=>array($membership_id, 'Integer')));
+    if ($contributionCount <= 1) {
+      // This is the first contribution of the membership do not update
+      // status and end date.
+      return;
+    }
+
     // Calculate new end date and set this as the new membership end date.
     $membership = civicrm_api3('Membership', 'getsingle', array('id' => $membership_id));
     $currentEndDate = new DateTime($membership['end_date']);


### PR DESCRIPTION
Fixes #34: do not update end date of membership when the first contribution is set to completed