### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Admin/Form/Setting/MembershipExtension.php
+++ b/CRM/Admin/Form/Setting/MembershipExtension.php
@@ -252,11 +252,11 @@ class CRM_Admin_Form_Setting_MembershipExtension extends CRM_Admin_Form_Setting 
     $settings->setSetting('sync_maximum_date', $values['sync_maximum_date'], FALSE);
     $settings->setSetting('membership_number_field',  $values['membership_number_field'], FALSE);
     $settings->setSetting('membership_number_generator',  $values['membership_number_generator'], FALSE);
-    $settings->setSetting('membership_number_show', CRM_Utils_Array::value('membership_number_show', $values), FALSE);
-    $settings->setSetting('hide_auto_renewal', CRM_Utils_Array::value('hide_auto_renewal', $values), FALSE);
+    $settings->setSetting('membership_number_show', $values['membership_number_show'] ?? NULL, FALSE);
+    $settings->setSetting('hide_auto_renewal', $values['hide_auto_renewal'] ?? NULL, FALSE);
     $settings->setSetting('paid_via_field',  $values['paid_via_field'], FALSE);
-    $settings->setSetting('record_fee_updates', CRM_Utils_Array::value('record_fee_updates', $values), FALSE);
-    $settings->setSetting('update_membership_status',  CRM_Utils_Array::value('update_membership_status', $values), FALSE);
+    $settings->setSetting('record_fee_updates', $values['record_fee_updates'] ?? NULL, FALSE);
+    $settings->setSetting('update_membership_status',  $values['update_membership_status'] ?? NULL, FALSE);
     $settings->setSetting('paid_by_field',   $values['paid_by_field'], FALSE);
     $settings->setSetting('annual_amount_field',        $values['annual_amount_field'], FALSE);
     $settings->setSetting('installment_amount_field',   $values['installment_amount_field'], FALSE);

--- a/CRM/Membership/CustomData.php
+++ b/CRM/Membership/CustomData.php
@@ -796,7 +796,7 @@ class CRM_Membership_CustomData
                 return $field_data['value'];
             } else {
                 // unlikely, but worth a shot:
-                return CRM_Utils_Array::value("custom_{$field_id}", $params, null);
+                return $params["custom_{$field_id}"] ?? NULL;
             }
         }
         return null;
@@ -848,9 +848,9 @@ class CRM_Membership_CustomData
                 'value' => $value,
                 'type' => CRM_Utils_Array::value('data_type', $field_specs, 'String'),
                 'custom_field_id' => $field_id,
-                'custom_group_id' => CRM_Utils_Array::value('custom_group_id', $field_specs, null),
-                'table_name' => CRM_Utils_Array::value('table_name', $group_specs, null),
-                'column_name' => CRM_Utils_Array::value('column_name', $field_specs, null),
+                'custom_group_id' => $field_specs['custom_group_id'] ?? NULL,
+                'table_name' => $group_specs['table_name'] ?? NULL,
+                'column_name' => $field_specs['column_name'] ?? NULL,
                 'is_multiple' => CRM_Utils_Array::value('is_multiple', $group_specs, 0),
             ];
         } else {

--- a/CRM/Membership/Form/Report/OutstandingMembershipFees.php
+++ b/CRM/Membership/Form/Report/OutstandingMembershipFees.php
@@ -306,7 +306,7 @@ class CRM_Membership_Form_Report_OutstandingMembershipFees extends CRM_Report_Fo
               $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
             }
             $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);              
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;              
           }
         }
       }
@@ -350,20 +350,20 @@ class CRM_Membership_Form_Report_OutstandingMembershipFees extends CRM_Report_Fo
         foreach ($table['filters'] as $fieldName => $field) {
           $clause = NULL;
           if (CRM_Utils_Array::value('operatorType', $field) & CRM_Utils_Type::T_DATE) {
-            $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-            $from     = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-            $to       = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
+            $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+            $from     = $this->_params["{$fieldName}_from"] ?? NULL;
+            $to       = $this->_params["{$fieldName}_to"] ?? NULL;
 
             $clause = $this->dateClause($field['name'], $relative, $from, $to, $field['type']);
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             if ($op) {
               $clause = $this->whereClause($field,
                 $op,
-                CRM_Utils_Array::value("{$fieldName}_value", $this->_params),
-                CRM_Utils_Array::value("{$fieldName}_min", $this->_params),
-                CRM_Utils_Array::value("{$fieldName}_max", $this->_params)
+                $this->_params["{$fieldName}_value"] ?? NULL,
+                $this->_params["{$fieldName}_min"] ?? NULL,
+                $this->_params["{$fieldName}_max"] ?? NULL
               );
             }
           }


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.