### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Membership/NumberLogic.php
+++ b/CRM/Membership/NumberLogic.php
@@ -52,7 +52,7 @@ class CRM_Membership_NumberLogic {
      * @param  $contact_ids array contact IDs
      * @param $membership_type_ids array list of potential membership type IDs
      * @return array contact id => membership number
-     * @throws API_Exception
+     * @throws CRM_Core_Exception
      */
     public static function getCurrentMembershipNumbers($contact_ids, $membership_type_ids = NULL) {
       $contact_id_2_membership_number = array();

--- a/CRM/Membership/TokenLogic.php
+++ b/CRM/Membership/TokenLogic.php
@@ -88,7 +88,7 @@ class CRM_Membership_TokenLogic {
    *  add more membership related tokens
    *
    * @param $tokens
-   * @throws CiviCRM_API3_Exception
+   * @throws CRM_Core_Exception
    */
   public function tokens(&$tokens) {
     $settings = CRM_Membership_Settings::getSettings();
@@ -170,7 +170,7 @@ class CRM_Membership_TokenLogic {
 
   /**
    * @return null
-   * @throws CiviCRM_API3_Exception
+   * @throws CRM_Core_Exception
    */
   protected function getMembershipTypes() {
     if ($this->_membershipTypes == NULL) {

--- a/tests/phpunit/MembershipTestBase.php
+++ b/tests/phpunit/MembershipTestBase.php
@@ -194,7 +194,7 @@ class MembershipTestBase extends \PHPUnit\Framework\TestCase implements Headless
    * @param $change_date
    * @param $old_amount
    * @param $new_amount
-   * @throws CiviCRM_API3_Exception
+   * @throws CRM_Core_Exception
    */
   public function createChangeActivity($membership, $change_date, $old_amount, $new_amount) {
     $change_logic = CRM_Membership_FeeChangeLogic::getSingleton();


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.